### PR TITLE
Add github action 'docker-publish'

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,12 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: run tests
-        run: |
-          set -x
-          [ -f docker-compose.test.yml ] || exit 0
-
-          docker-compose --file docker-compose.test.yml build
-          docker-compose --file docker-compose.test.yml run sut
+        run: make test
 
   push:
     needs: test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: docker-publish
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+  pull_request: # run job 'test'
+
+env:
+  IMAGE_NAME: covid-data-hub-server
+  REGISTRY: docker.pkg.github.com
+  AUTH: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: run tests
+        run: |
+          set -x
+          [ -f docker-compose.test.yml ] || exit 0
+
+          docker-compose --file docker-compose.test.yml build
+          docker-compose --file docker-compose.test.yml run sut
+
+  push:
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build image
+        run: docker build . --tag $IMAGE_NAME
+
+      - name: log into registry
+        run: docker login $REGISTRY -u ${{ github.actor }}
+             --password-stdin <<< "$AUTH"
+
+      - name: push image
+        run: |
+          VERSION=$(sed 's|refs/tags/v|| ; s|.*/||' <<< "${{ github.ref }}")
+          IMAGE_ID=$REGISTRY/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=$(tr '[A-Z]' '[a-z]' <<< "$IMAGE_ID")
+
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          docker tag  $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,11 @@ migrate:
 db_upgrade:
 	docker-compose run --rm server python manage.py db upgrade
 
+clean: containers = hub_testdb_1 hub_db_1
+clean:
+	docker stop ${containers}
+	docker rm   ${containers}
+	docker-compose down
+
 .env:
 	cp .env-template $@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: .env
 run:
 	docker-compose up -d
 
-test:
+test: build
 	docker-compose -f docker-compose.yml -f docker-compose-test.yml run --rm server
 
 initdb:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: .env
 run:
 	docker-compose up -d
 
-test: build
+test: build test_db
 	docker-compose -f docker-compose.yml -f docker-compose-test.yml run --rm server
 
 initdb:
@@ -15,6 +15,11 @@ migrate:
 
 db_upgrade:
 	docker-compose run --rm server python manage.py db upgrade
+
+test_db: compose.files = -f docker-compose.yml -f docker-compose-test.yml
+test_db:
+	docker-compose ${compose.files} up -d testdb
+	docker-compose ${compose.files} exec -T testdb pg_isready
 
 clean: containers = hub_testdb_1 hub_db_1
 clean:


### PR DESCRIPTION
This PR adds a "docker publish" github action workflow
(based on template proposed by gh).

Provides for:
- running test on (most) git pushes to the repo (master, tags, and PR)
- docker image publication to github packages docker registry

Notes:
1. image publication happens only for pushes to master or tag pushes
    i.e. _not_ for PR.
2. the github packages docker registry requires token auth to pull images.